### PR TITLE
删除CNAME文件，用于直接不映射到私有域名，直接可以 https://zhangyuying-cn.github.io/ 访问

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-zhangyuying-cn.github.io

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-zhangyuying.top
+zhangyuying-cn.github.io

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-Zhangyuying.top
+zhangyuying.top

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+Zhangyuying.top


### PR DESCRIPTION
update: 删除CNAME文件，用于直接不映射到私有域名，直接可以 https://zhangyuying-cn.github.io/ 访问